### PR TITLE
roles/kerberos5: Drop single-DES enctypes

### DIFF
--- a/roles/kerberos5/templates/kdc.conf.j2
+++ b/roles/kerberos5/templates/kdc.conf.j2
@@ -11,7 +11,7 @@
   acl_file = {{ kdc_var_path }}/kadm5.acl
   dict_file = /usr/share/dict/words
   admin_keytab = {{ kdc_var_path }}/kadm5.keytab
-  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal
  }
 
 [logging]


### PR DESCRIPTION
I'm not sure that this is enough, but I don't really know how to test.